### PR TITLE
Add error msg for Error 69 in DreameValetudoRobot.js

### DIFF
--- a/backend/lib/robots/dreame/DreameValetudoRobot.js
+++ b/backend/lib/robots/dreame/DreameValetudoRobot.js
@@ -825,11 +825,15 @@ DreameValetudoRobot.MAP_ERROR_CODE = (vendorErrorCode) => {
             parameters.subsystem = ValetudoRobotError.SUBSYSTEM.NAVIGATION;
             parameters.message = "Cannot reach target";
             break;
-            // 68: Not an Error. "Docked but mop is still attached. Please remove the mop"
-
+        // 68: Not an Error. "Docked but mop is still attached. Please remove the mop"
+	case "69":
+            parameters.severity.kind = ValetudoRobotError.SEVERITY_KIND.PERMANENT;
+            parameters.severity.level = ValetudoRobotError.SEVERITY_LEVEL.ERROR;
+            parameters.subsystem = ValetudoRobotError.SUBSYSTEM.ATTACHMENTS;
+            parameters.message = "Lost mop pad";
+            break;
             /*
-                TODO figure out what these p2027 codes mean
-                69 "AVA_HEALTH_STATUS_TYPE_MOP_CHECK"
+                TODO figure out what this p2027 code means
                 70 "AVA_HEALTH_STATUS_TYPE_FASTMAPMODE_MOPCHECK"
              */
 


### PR DESCRIPTION
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Docs
- [ ] Refactor/Code Cleanup

# Description
Hi,
thanks for maintaining Valetudo.

My L10SUltra lost its mop pad while cleaning and reported: 

> An error occurred: Unknown error 69

So I added a more specific error msg in `DreameValetudoRobot.js`.
Since the `p2027` also has mop-pads, I believe the error code should be the same for all mop-based robots but I can't test this.

